### PR TITLE
update build and project identifiers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <version.junit>4.12</version.junit>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <module.name>me.nlighten.wildfly-flyway-extension</module.name>
+    <module.path>me/nlighten/wildfly-flyway-extension</module.path>
     <!--set source level to 1.8 -->
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -34,46 +35,24 @@
     <finalName>${project.artifactId}</finalName>
     <plugins>
       <plugin>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <configuration>
-          <filters>
-            <filter>src/assemble/filter.properties</filter>
-          </filters>
-          <descriptors>
-            <descriptor>src/assemble/distribution.xml</descriptor>
-          </descriptors>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
-        <!--<inherited>false</inherited>-->
+        <inherited>false</inherited>
         <version>1.8</version>
         <executions>
           <execution>
             <phase>package</phase>
-            <!--            <id>build-dist</id>-->
+              <id>build-dist</id>
             <goals>
               <goal>run</goal>
             </goals>
-           
             <configuration>
               <target>
-                <!-- Replace the '.' in ${module.name} with '/' to get its path -->
-                <tempfile property="temp.file" />
-                <echo message="${module.name}" file="${temp.file}" />
-                <replace file="${temp.file}" token="." value="/" />
-                <loadfile srcfile="${temp.file}" property="module.path" />
-                <delete file="${temp.file}" />
-                <echo>Vars: temp.file ${temp.file} mod.path ${module.path}</echo>
-
                 <delete dir="target/module" />
                 <property name="module.dir" value="target/module/${module.path}/main" />
-
                 <copy file="src/main/resources/module/main/module.xml" tofile="${module.dir}/module.xml" />
                 <copy file="target/${project.artifactId}.jar" todir="${module.dir}" />
                 <copy file="${org.flywaydb:flyway-core:jar}" todir="${module.dir}" />
-
                 <echo>Module ${module.name} has been created in the target/module directory. Copy to
                   your WildFly installation.</echo>
                 <zip destfile="target/module.zip" basedir="target/module/"   /> 
@@ -102,6 +81,43 @@
       </plugin>-->
     </plugins>
   </build>
+  
+  <profiles>
+      <profile>
+          <id>add-to-wildfly</id>
+          <build>
+              <plugins>
+                  <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <inherited>false</inherited>
+                    <version>1.8</version>
+                    <executions>
+                      <execution>
+                        <phase>package</phase>
+                          <id>install-to-server</id>
+                        <goals>
+                          <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
+                            <copy todir="${wildfly.home}/modules/">
+                                <fileset dir="target/module" includes="**/*" />
+                               </copy>
+                                <echo>Module ${module.name} has been copied to ${wildfly.home}/modules.</echo>
+                            </tasks>
+<!--                          <target>
+                            <copy  folder="target/module" tofile="${wildfly.home}/modules/" />
+                            <echo>Module ${module.name} has been copied to ${wildfly.home}/modules.</echo>
+                          </target>-->
+                        </configuration>
+                      </execution>
+                    </executions>
+                  </plugin>
+              </plugins>
+          </build>
+      </profile>
+  </profiles>
 
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,20 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.jboss</groupId>
-    <artifactId>jboss-parent</artifactId>
-    <version>20</version>
-    <relativePath />
-  </parent>
-
-  <groupId>me.jboss.flyway</groupId>
-  <artifactId>flyway-extension</artifactId>
+  <groupId>me.nlighten</groupId>
+  <artifactId>wildfly-flyway-extension</artifactId>
   <version>1.0-SNAPSHOT</version>
 
-  <name>WildFly: Subsystem Artifact</name>
+  <name>Wildfly FlyWay Extension</name>
 
   <packaging>jar</packaging>
 
@@ -22,14 +15,20 @@
     <version.wildfly.core>2.0.10.Final</version.wildfly.core>
     <version.junit>4.12</version.junit>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <module.name>me.jboss.flyway</module.name>
+    <module.name>me.nlighten.wildfly-flyway-extension</module.name>
     <!--set source level to 1.8 -->
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
     <version.flyway>4.0.3</version.flyway>
-    <jboss.home></jboss.home>
   </properties>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <id>jboss-releases</id>
+      <name>jboss-releases</name>
+      <url>https://repository.jboss.org/nexus/content/repositories/releases/</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <build>
     <finalName>${project.artifactId}</finalName>
@@ -48,14 +47,16 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
-        <inherited>false</inherited>
+        <!--<inherited>false</inherited>-->
+        <version>1.8</version>
         <executions>
           <execution>
-            <id>build-dist</id>
+            <phase>package</phase>
+            <!--            <id>build-dist</id>-->
             <goals>
               <goal>run</goal>
             </goals>
-            <phase>package</phase>
+           
             <configuration>
               <target>
                 <!-- Replace the '.' in ${module.name} with '/' to get its path -->
@@ -64,79 +65,72 @@
                 <replace file="${temp.file}" token="." value="/" />
                 <loadfile srcfile="${temp.file}" property="module.path" />
                 <delete file="${temp.file}" />
+                <echo>Vars: temp.file ${temp.file} mod.path ${module.path}</echo>
 
                 <delete dir="target/module" />
                 <property name="module.dir" value="target/module/${module.path}/main" />
 
                 <copy file="src/main/resources/module/main/module.xml" tofile="${module.dir}/module.xml" />
                 <copy file="target/${project.artifactId}.jar" todir="${module.dir}" />
+                <copy file="${org.flywaydb:flyway-core:jar}" todir="${module.dir}" />
 
                 <echo>Module ${module.name} has been created in the target/module directory. Copy to
                   your WildFly installation.</echo>
+                <zip destfile="target/module.zip" basedir="target/module/"   /> 
               </target>
             </configuration>
           </execution>
         </executions>
       </plugin>
+      <!--      <plugin>
+        <groupId>org.wildfly.plugins</groupId>
+        <artifactId>wildfly-extension-maven-plugin</artifactId>
+        <version>0.7.0</version>
+        <configuration>
+          <moduleZip>${project.build.directory}/module.zip</moduleZip>
+          <jbossHome>${wildfly_home}/</jbossHome>
+        </configuration>
+        <executions>
+          <execution>
+            <id>build-dist</id>
+            <phase>install</phase>
+            <goals>
+              <goal>deploy</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>-->
     </plugins>
   </build>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.wildfly.core</groupId>
-        <artifactId>wildfly-controller</artifactId>
-        <version>${version.wildfly.core}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.wildfly.core</groupId>
-        <artifactId>wildfly-server</artifactId>
-        <version>${version.wildfly.core}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.wildfly.core</groupId>
-        <artifactId>wildfly-subsystem-test</artifactId>
-        <type>pom</type>
-        <scope>test</scope>
-        <version>${version.wildfly.core}</version>
-      </dependency>
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <scope>test</scope>
-        <version>${version.junit}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.flywaydb</groupId>
-        <artifactId>flyway-core</artifactId>
-        <version>${version.flyway}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
       <groupId>org.wildfly.core</groupId>
       <artifactId>wildfly-controller</artifactId>
+      <version>${version.wildfly.core}</version>
     </dependency>
     <dependency>
       <groupId>org.wildfly.core</groupId>
       <artifactId>wildfly-server</artifactId>
+      <version>${version.wildfly.core}</version>
     </dependency>
     <dependency>
       <groupId>org.wildfly.core</groupId>
       <artifactId>wildfly-subsystem-test</artifactId>
+      <version>${version.wildfly.core}</version>
       <type>pom</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-core</artifactId>
+      <version>${version.flyway}</version>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/java/me/jboss/flyway/deployment/SubsystemDeploymentProcessor.java
+++ b/src/main/java/me/jboss/flyway/deployment/SubsystemDeploymentProcessor.java
@@ -1,10 +1,14 @@
 package me.jboss.flyway.deployment;
 
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
 import javax.naming.InitialContext;
-import javax.naming.NamingException;
 import javax.sql.DataSource;
 
 import org.flywaydb.core.Flyway;
+import org.jboss.logging.Logger;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
@@ -21,31 +25,81 @@ import org.jboss.vfs.VirtualFile;
  * <li>Replacing a deployment descriptor with a transformed version of that descriptor</li>
  * <li>Removing a deployment descriptor to prevent it from being processed</li>
  * </ol>
- * 
+ * .
+ *
  * @author lubo
  */
 public class SubsystemDeploymentProcessor implements DeploymentUnitProcessor {
+
+  private static Logger LOGGER = Logger.getLogger(SubsystemDeploymentProcessor.class);
+  
+  private static final String DEFAULT_DATASOURCE_NAME = "java:comp/DefaultDataSource";
+  /** The migration folder path. */
+  private static String MIGRATION_FOLDER_PATH = "WEB-INF/classes/db/migration";
+
+  /** The persistence xml path. */
+  private static String PERSISTENCE_XML_PATH = "src/main/resources/persistence.xml";
+
+  /** The datasource element. */
+  private static String DATASOURCE_ELEMENT = "jta-data-source";
+
+  /** The datasource regex. */
+  private static String DATASOURCE_REGEX = "</?jta-data-source>";
 
   /** {@inheritDoc} */
   @Override
   public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
     ResourceRoot root = phaseContext.getDeploymentUnit().getAttachment(Attachments.DEPLOYMENT_ROOT);
-    try {
-      InitialContext initialContext = new InitialContext();
-      DataSource dataSource =
-          (DataSource) initialContext.lookup("java:jboss/datasources/ExampleDS");
-      VirtualFile migrationFolder = root.getRoot().getChild("WEB-INF/classes/db/migration");
-      if (migrationFolder.exists()) {
+    VirtualFile migrationFolder = root.getRoot().getChild(MIGRATION_FOLDER_PATH);
+    if (migrationFolder.exists()) {
+      DataSource dataSource = getDatasource(root);
+      if (dataSource != null) {
         Flyway flyway = new Flyway();
         flyway.setDataSource(dataSource);
         flyway.migrate();
       }
-    } catch (NamingException e) {
-      e.printStackTrace();
     }
   }
 
   /** {@inheritDoc} */
   @Override
   public void undeploy(DeploymentUnit context) {}
+
+  /**
+   * Gets the datasource.
+   *
+   * @param root the root
+   * @return the datasource
+   */
+  private DataSource getDatasource(ResourceRoot root) {
+    VirtualFile persistenceXml = root.getRoot().getChild(PERSISTENCE_XML_PATH);
+    DataSource dataSource = null;
+    try {
+      InitialContext initialContext = new InitialContext();
+      if (persistenceXml.exists()) {
+        String line;
+        InputStream is = persistenceXml.openStream();
+        BufferedReader br = new BufferedReader(new InputStreamReader(is));
+        String datasourceName = null;
+        while ((line = br.readLine()) != null) {
+          if (line.contains(DATASOURCE_ELEMENT)) {
+            datasourceName = line.replaceAll(DATASOURCE_REGEX, "").trim();
+            break;
+          }
+        }
+        if (datasourceName != null && !datasourceName.isEmpty()) {
+          dataSource = (DataSource) initialContext.lookup(datasourceName);
+        } else {
+            //JEE7 - no datasource=default datasource
+            dataSource = (DataSource) initialContext.lookup(DEFAULT_DATASOURCE_NAME);
+        }
+      } else {
+         LOGGER.warn("No JPA context marker found. Proceed with custom datasource.");
+      }
+    } catch (Exception e) {
+      LOGGER.error("Could not determine datasource for Flyway migration", e);
+    }
+    return dataSource;
+  }
+
 }

--- a/src/main/resources/module/main/module.xml
+++ b/src/main/resources/module/main/module.xml
@@ -1,6 +1,7 @@
 <module xmlns="urn:jboss:module:1.1" name="me.jboss.flyway">
   <resources>
-    <resource-root path="flyway-extension.jar" />
+    <resource-root path="wildfly-flyway-extension.jar" />
+    <resource-root path="flyway-core-4.0.3.jar" />
   </resources>
 
   <dependencies>
@@ -12,5 +13,7 @@
     <module name="org.jboss.msc" />
     <module name="org.jboss.logging" />
     <module name="org.jboss.vfs" />
+    <module name="org.jboss.as.connector"/>
+    <module name="org.jboss.as.naming"/>
   </dependencies>
 </module>

--- a/src/main/resources/module/main/module.xml
+++ b/src/main/resources/module/main/module.xml
@@ -1,4 +1,4 @@
-<module xmlns="urn:jboss:module:1.1" name="me.jboss.flyway">
+<module xmlns="urn:jboss:module:1.1" name="me.nlighten.wildfly-flyway-extension">
   <resources>
     <resource-root path="wildfly-flyway-extension.jar" />
     <resource-root path="flyway-core-4.0.3.jar" />


### PR DESCRIPTION
Changes proposed in this PR:

- changed maven group/artifact to more appropriate values
- add flyway jar automatically to module during build
- add profile to install module into existing wildfly using `mvn clean install -Padd-to-wildfly -Dwildfly.home=PATH_TO_WILDFLY`
- add support for Default datasource in case the persistence.xml does not contain JTA ds.

Feel free to pick the parts you consider useful or suggest further edits. 